### PR TITLE
Fix `aplha` typo in `ColorObject` typings.

### DIFF
--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -14,7 +14,7 @@ declare module 'material-ui-color' {
     hex: string;
     raw: string | number | object | string[] | number[];
     name: string;
-    aplha: number;
+    alpha: number;
     rgb: [number, number, number];
     hsv: [number, number, number];
     hsl: [number, number, number];


### PR DESCRIPTION
### Fix issues

- N/A

### Description

Fixes typo in typings for `ColorObject` which have `aplha` where it should be `alpha`.

### Check List

It's swapping two characters so I'm gonna say it passes the checklist.

- [x] respect code conventions and usages
- [x] tests and 100% coverage
- [x] well documented
- [x] self review

### Review targets:
- nodejs / npm / yarn